### PR TITLE
Add a function to set the value of the environment variable

### DIFF
--- a/envy.asd
+++ b/envy.asd
@@ -16,6 +16,7 @@
   :version "0.1"
   :author "Eitarow Fukamachi"
   :license "BSD 2-Clause"
+  :depends-on (:osicat)
   :components ((:module "src"
                 :components
                 ((:file "envy"))))

--- a/src/envy.lisp
+++ b/src/envy.lisp
@@ -8,7 +8,9 @@
   (:use :cl)
   (:export :config-env-var
            :defconfig
-           :config))
+           :config
+           :env-var
+           :remove-env-var))
 (in-package :envy)
 
 (defvar *config-env-map* (make-hash-table :test 'equal))
@@ -52,3 +54,12 @@
   (if key
       (getf (package-config package-name) key)
       (package-config package-name)))
+
+(defun env-var (var)
+  (osicat:environment-variable var))
+
+(defun (setf env-var) (val var)
+  (setf (osicat:environment-variable var) val))
+
+(defun remove-env-var (var)
+  (osicat:makunbound-environment-variable var))

--- a/t/envy.lisp
+++ b/t/envy.lisp
@@ -8,7 +8,8 @@
   (:use :cl)
   (:import-from :envy
                 :config-env-var
-                :defconfig))
+                :defconfig
+                :env-var))
 (in-package :envy.myapp.config)
 
 (setf (config-env-var) "APP_ENV")
@@ -33,10 +34,7 @@
 (defpackage envy-test
   (:use :cl
         :envy
-        :cl-test-more)
-  (:import-from :osicat
-                :environment-variable
-                :makunbound-environment-variable))
+        :cl-test-more))
 (in-package :envy-test)
 
 (plan 9)
@@ -47,7 +45,7 @@
   (environment-variable *env-var*))
 
 (diag "development")
-(setf (environment-variable *env-var*) "development")
+(setf (env-var *env-var*) "development")
 
 (is (getf (config :envy.myapp.config) :a) 1)
 (is (getf (config :envy.myapp.config) :b) 2)
@@ -56,7 +54,7 @@
     "Has a common configuration")
 
 (diag "production")
-(setf (environment-variable *env-var*) "production")
+(setf (env-var *env-var*) "production")
 
 (is (getf (config :envy.myapp.config) :a) 10)
 (is (getf (config :envy.myapp.config) :b) 200)
@@ -65,7 +63,7 @@
     "Has a common configuration")
 
 (diag "staging")
-(setf (environment-variable *env-var*) "staging")
+(setf (env-var *env-var*) "staging")
 
 (is (getf (config :envy.myapp.config) :a) 0
     "Can override a parent configuration")
@@ -78,5 +76,5 @@
 (finalize)
 
 (if *env-backup*
-    (setf (environment-variable *env-var*) *env-backup*)
-    (makunbound-environment-variable *env-var*))
+    (setf (env-var *env-var*) *env-backup*)
+    (remove-env-var *env-var*))


### PR DESCRIPTION
Users shouldn't have to care how the configuration variable is set internally, so I added a little functionality to set the value of a given env var.
